### PR TITLE
Fix some bugs + add helper stuff

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -65,4 +65,6 @@ def Print(a1, ctx=None):
 
 def Power(a1, a2, ctx=None):
     """Calculates a1 to the power of a2"""
-    return a1**a2
+    # fmt: off
+    return a1 ** a2
+    # fmt: on

--- a/functions.py
+++ b/functions.py
@@ -1,3 +1,5 @@
+from helper import IsType
+
 g = "Hello, World!"
 w = "Hello World"
 b = "0123456789"
@@ -27,11 +29,10 @@ p8 = 128
 
 def Add(a1, a2, ctx=None):
     """Add two numbers"""
-
-    if isinstance(a1, str) and isinstance(a2, int):
-        return a1 + str(a2)
-
-    return a1 + a2
+    if IsType(args=[a1, a2], types=[str, int]):
+        return str(a1) + str(a2)
+    else:
+        return a1 + a2
 
 
 def Sub(a1, a2, ctx=None):
@@ -47,7 +48,9 @@ def Mul(a1, a2, ctx=None):
 def TrueDiv(a1, a2, ctx=None):
     """Divides two numbers"""
     if a2 == 0:
-        return float(f"{'-' if a1 < 0 else ''}Infinity")  # Although negative numbers are not supported (yet)
+        return float(
+            f"{'-' if a1 < 0 else ''}Infinity"
+        )  # Although negative numbers are not supported (yet)
 
     return a1 / a2
 
@@ -62,4 +65,4 @@ def Print(a1, ctx=None):
 
 def Power(a1, a2, ctx=None):
     """Calculates a1 to the power of a2"""
-    return a1 ** a2
+    return a1**a2

--- a/helper.py
+++ b/helper.py
@@ -1,5 +1,15 @@
 """File for helper functions"""
 from typing import Union
-from tokenizer import Token
+from tokenizer import Token, TokenType
+from collections import Counter
 
 TokenList = Union[Token, list[Token]]
+Literals = [TokenType.NUMBER, TokenType.STRING]
+
+
+def Types(*a):
+    return list(map(type, a))
+
+
+def IsType(args, types):
+    return Counter(Types(*args)) == Counter(types)

--- a/interpreter.py
+++ b/interpreter.py
@@ -1,32 +1,35 @@
 from elements import elements
-from helper import TokenList
+from helper import Literals
 from typing import Any
 
 
 class Interprete:
     def main(self, tokens: list[Any], ctx):
+
+        if len(tokens) == 1 and not callable(tokens[0]):
+            # If tokens is a single literal wrapped in a list, the interpreter will crash
+            # So if tokens[0] is a literal, then unwrap it
+            tokens = tokens[0]
+
         self.output = []
         main_output = self.interprete(tokens, ctx)
+
         self.output.insert(0, main_output) if main_output else None
         return self.output
 
     def interprete(self, tokens: list[Any], ctx) -> Any:
         if type(tokens) is list:  # If tokens are grouped
-            if len(tokens) == 1 and type(tokens[0]) is list:
-                tokens = tokens[0]
-
             if type(tokens[0]) is list:  # If the func part actually is a list
                 # then there are more tokens in the stack to be outputted
+                # Example: "+2 3 4"
                 for token in tokens:
                     output = self.interprete(token, ctx=ctx)
                     self.output.append(output)
             else:
-                func = elements.get(tokens[0])
+                func = tokens[0]
 
-                # Exit if func does not exist else get the lambda of the element
-                if func:
-                    func = func[1]
-                else:
+                # Exit if func does not exist
+                if not func:
                     return [None]
 
                 args = []  # Interprete every argument, recursive case

--- a/parse.py
+++ b/parse.py
@@ -1,5 +1,6 @@
 from tokenizer import Token, TokenType, tokenize
 from collections import deque
+from helper import Literals
 from elements import elements
 
 
@@ -19,7 +20,7 @@ def parse(token_list: list[Token]) -> list[Token]:
         if token.name == TokenType.FUNCTION:
             if not tokens:  # account for there not being anything
                 # after this token by just breaking the loop
-                parse_list.append(token.value)
+                parse_list.append(elements[token.value][1])
                 break
             arity = elements[token.value][0]
             temp = parse(list(tokens))  # This works
@@ -27,10 +28,12 @@ def parse(token_list: list[Token]) -> list[Token]:
             # number of constants/nilads) form single units, and non-
             # complete functions (functions and a non-complete number
             # of constants/nilads) can use those single units.
-            parse_list.append([token.value] + temp[:arity])  # Arity appended to list because function might have args
+            parse_list.append(
+                [elements[token.value][1]] + temp[:arity]
+            )  # Arity appended to list because function might have args
             parse_list += temp[arity:]
             break  # break because everything is parsed (complete)
-        elif token.name in {TokenType.NUMBER, TokenType.STRING}:
+        elif token.name in Literals:
             parse_list.append(token.value)  # Literals don't need any special treatment
 
     return parse_list
@@ -38,4 +41,4 @@ def parse(token_list: list[Token]) -> list[Token]:
 
 if __name__ == "__main__":
     print(parse(tokenize("+1 +3 +4 5")))
-    print(parse(tokenize("+1 +3 4 +5 6")))
+    print(parse(tokenize("g")))


### PR DESCRIPTION
[As explained in chat](https://chat.stackexchange.com/transcript/message/60525762#60525762), the bug was that a single niladic function (0 arguments) like `g` will not be in a list and therefore act like a string, not a function.
So now the parser already gets the lambda of a function like g.
I put `Literals = [TokenType.NUMBER, TokenType.STRING]` in helper.py (it just looks better).
If you do `if isinstance(a1, str) and isinstance(a2, int):`, you'd have to check the other way around to, so I made two functions in helper.py:
1. Types(a1, a2, a3): Returns `type` of each of those in a list
2. IsType(args, types): Checks if `args` in any order match `types`.
So now you can do `if IsType(args=[a1, a2], types=[str, int]):` and it will check the other way too.

(And my auto-formatter (black) made some other changes, delete them if you like)