### PR TITLE
For Loops are now working!

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 Update 3/9/2022:  
-&nbsp;&nbsp;&nbsp;&nbsp;Added the int input element (Ŋ) and the sum digits/sum code points element. (Đ)
+- Added the int input element (Ŋ) and the sum digits/sum code points element. (Đ)
 
 Update 3/8/2022:  
-&nbsp;&nbsp;&nbsp;&nbsp;Changed elements.py and parser.py to use the Element(arity, func) syntax instead of a list.
+- Changed elements.py and parser.py to use the Element(arity, func) syntax instead of a list.
+
+Update 3/11/2022:
+- Add For Loop support with structure.py and unpack.py

--- a/functions.py
+++ b/functions.py
@@ -72,7 +72,7 @@ def TrueDiv(a, b, ctx=ctx):
 
 def Print(a, ctx=ctx):
     """Print with newline"""
-    ctx.print = print_with_newline(a)
+    ctx.print += print_with_newline(a)
     ctx.printed = True
     return a
 

--- a/interpreter.py
+++ b/interpreter.py
@@ -1,8 +1,10 @@
 from typing import Any
+from structure import structure
 
 from tokenizer import tokenize
 from parse import parse
 from context import Context
+from unpack import unpack
 
 
 class Interprete:
@@ -50,4 +52,4 @@ class Interprete:
 
 
 def run(text, ctx=Context()):
-    return Interprete().main(parse(tokenize(text)), ctx)
+    return Interprete().main(parse(unpack(structure(tokenize(text)))), ctx)

--- a/structure.py
+++ b/structure.py
@@ -19,7 +19,7 @@ class ForLoop:
         return f"ForLoop(number={self.number}, body={self.body})"
 
 
-def structure(tokens):
+def structure_forLoop(tokens):
     """
     Groups tokens together to structures
     """
@@ -50,6 +50,9 @@ def structure(tokens):
                 structured_tokens.append(token)
 
     return structured_tokens
+
+def structure(tokens):
+    return structure_forLoop(tokens)
 
 
 if __name__ == "__main__":

--- a/tokenizer.py
+++ b/tokenizer.py
@@ -139,8 +139,4 @@ def tokenize(text: str) -> list[Token]:
 
 
 if __name__ == "__main__":
-    print(tokenize("+7 59*89 / 207"))
-    print(tokenize("+1 +3 4"))
-    print(tokenize('2 "s1" 3 "s2" "s3'))
-    print(tokenize('12.34 2 "abc" 3.7'))
-    print(tokenize("↹2{¶1}"))
+    print(tokenize("+1 2"))

--- a/unittests/noxan_tests.py
+++ b/unittests/noxan_tests.py
@@ -1,0 +1,14 @@
+import unittest, init
+
+from interpreter import run
+from tokenizer import tokenize, Token, TokenType
+from structure import structure, ForLoop
+
+
+class TokenizerTests(unittest.TestCase):
+    def test_tokenizer(self):
+        pass
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unpack.py
+++ b/unpack.py
@@ -1,5 +1,6 @@
-from tokenizer import Token
+from tokenizer import Token, tokenize
 from structure import ForLoop
+from structure import structure
 
 
 def unpack_forLoop(tokens):
@@ -13,3 +14,11 @@ def unpack_forLoop(tokens):
                 unpacked_tokens.extend(token.body)
 
     return unpacked_tokens
+
+
+def unpack(tokens):
+    return unpack_forLoop(tokens)
+
+
+if __name__ == "__main__":
+    print(unpack(structure(tokenize("+2 3↹4{¶1} 5"))))


### PR DESCRIPTION
Just changed `interpreter.run()` to do `.main(parse(unpack(structure(tokenize(text)))), ctx)`.
And fixed a tiny bug where `¶1¶2` would just print `2`. (see `functions.py`)