### PR TITLE
Make adding elements work

### DIFF
--- a/codepage.py
+++ b/codepage.py
@@ -1,8 +1,10 @@
-FUNCTIONS = ["+", "-", "×", "÷", "ⁱ", "g", "¶", "Đ", "Ŋ", "Ƣ", "!", "¡", "□", "i"]
+FUNCTIONS = []
+FUNCTIONS += ["+", "-", "×", "÷", "ⁱ", "g", "¶", "Đ"]
+FUNCTIONS += ["Ŋ", "Ƣ", "!", "¡", "□", "i", "s", "t"]
+FUNCTIONS += ["h"]
 
 INDICATORS = ["↹", "{", "}"]
 
 codepage = FUNCTIONS + INDICATORS
-codepage += [chr(x) for x in range(32, 126+1)]
 
 assert len(codepage) <= 256


### PR DESCRIPTION
Before elements were added directly to `codepage` (which the tokenizer can't recognize), not to `FUNCTIONS`.
And adding all ASCII chars to `codepage` is a bad idea because eg. `{}` are indicators, `sth` are elements, etc.